### PR TITLE
fix: catch undefined document in SSR

### DIFF
--- a/src/focus-trap/src/index.ts
+++ b/src/focus-trap/src/index.ts
@@ -38,7 +38,7 @@ export const FocusTrap = defineComponent({
     const focusableEndRef = ref<HTMLElement | null>(null)
     let activated = false
     let ignoreInternalFocusChange = false
-    const lastFocusedElement: Element | null = document.activeElement
+    const lastFocusedElement: Element | null = typeof document === 'undefined' ? null : document.activeElement
 
     function isCurrentActive (): boolean {
       const currentActiveId = stack[stack.length - 1]


### PR DESCRIPTION
In case the component is rendered in SSR mode it should avoid checking the `document` element because it will trigger an exception:
```
ReferenceError: document is not defined
    at setup (/home/coder/server/node_modules/vueuc/lib/focus-trap/src/index.js:33:36)
    at callWithErrorHandling (/home/coder/server/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:157:22)
    at setupStatefulComponent (/home/coder/server/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:7084:29)
    at setupComponent (/home/coder/server/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:7039:11)
    at renderComponentVNode (/home/coder/server/node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:172:17)
    at renderVNode (/home/coder/server/node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:295:22)
    at renderVNodeChildren (/home/coder/server/node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:310:9)
    at renderElementVNode (/home/coder/server/node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:361:17)
    at renderVNode (/home/coder/server/node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:292:17)
    at renderVNodeChildren (/home/coder/server/node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:310:9)
```