### PR TITLE
feat: prefer native ResizeObserver

### DIFF
--- a/src/resize-observer/src/delegate.ts
+++ b/src/resize-observer/src/delegate.ts
@@ -1,14 +1,14 @@
-import { ResizeObserver } from '@juggle/resize-observer'
+import { ResizeObserver as PolyfillResizeObserver } from '@juggle/resize-observer'
 
 type ResizeHandler = (entry: ResizeObserverEntry) => void
 
 class ResizeObserverDelegate {
   elHandlersMap: Map<Element, ResizeHandler>
-  observer: ResizeObserver
+  observer: PolyfillResizeObserver
 
   constructor () {
     this.handleResize = this.handleResize.bind(this)
-    this.observer = new ResizeObserver(this.handleResize)
+    this.observer = new (window.ResizeObserver || PolyfillResizeObserver)(this.handleResize)
     this.elHandlersMap = new Map()
   }
 


### PR DESCRIPTION
Again (https://github.com/07akioni/vueuc/issues/241), I noticed some performance issues with the resize observer:
<img width="283" alt="image" src="https://user-images.githubusercontent.com/5358638/209193577-8b77b1f1-0563-408b-8d53-b5f586ece8f9.png">

Hence, I thought that we could at least fall back to the polyfill if there is no native implementation. What do you think?