### PR TITLE
fix: ensure view measurer exists

### DIFF
--- a/src/binder/src/utils.ts
+++ b/src/binder/src/utils.ts
@@ -2,8 +2,12 @@ import { Rect } from './interface'
 
 let viewMeasurer: HTMLElement | null = null
 
+export function elementExists(el: HTMLElement): boolean {
+  return el.clientWidth > 0 || el.clientHeight > 0 || document.contains(viewMeasurer)
+}
+
 export function ensureViewBoundingRect (): DOMRect {
-  if (viewMeasurer === null) {
+  if (viewMeasurer === null || !elementExists(viewMeasurer)) {
     viewMeasurer = document.getElementById('v-binder-view-measurer')
     if (viewMeasurer === null) {
       viewMeasurer = document.createElement('div')


### PR DESCRIPTION
获取 `viewRect` 时确认 `view measurer` 存在与 document 上。

场景：

在微前端场景下，基座和子应用都使用了 `vueuc`，子应用先渲染 `VFollower`，此时会先在子应用中创建 `view measurer`。之后基座再渲染 `VFollower`，此时会查询到子应用创建的 `view measurer` 并缓存。

如果之后切换子应用，`view measurer` 被移除，此时基座的 `VFollower` 渲染就会存在异常。