### PR TITLE
fix(VirtualList): ensure scrollTo postion bottom  work

### DIFF
--- a/src/virtual-list/demo/App1.ts
+++ b/src/virtual-list/demo/App1.ts
@@ -54,6 +54,13 @@ export default defineComponent({
         ]),
         h('button', {
           onClick: () => {
+            this.listElRef.scrollTo({ position: 'bottom', behavior: this.scrollBehavior })
+          }
+        }, [
+          'scrollTo({ position: \'bottom\' })'
+        ]),
+        h('button', {
+          onClick: () => {
             this.scrollBehavior === 'auto' ? this.scrollBehavior = 'smooth' : this.scrollBehavior = 'auto'
           }
         }, [
@@ -64,7 +71,10 @@ export default defineComponent({
       h(VirtualList, {
         itemSize: 34,
         items: basicData,
-        ref: 'listElRef'
+        ref: 'listElRef',
+        onScroll: (e) => {
+          console.log(e)
+        }
       }, {
         default ({ item }: { item: ItemData }) {
           return h('div', {

--- a/src/virtual-list/demo/App2.ts
+++ b/src/virtual-list/demo/App2.ts
@@ -135,6 +135,13 @@ export default defineComponent({
         ]),
         h('button', {
           onClick: () => {
+            this.listElRef.scrollTo({ position: 'bottom', behavior: this.scrollBehavior, debounce: this.debounce })
+          }
+        }, [
+          'scrollTo({ position: \'bottom\' })'
+        ]),
+        h('button', {
+          onClick: () => {
             this.scrollBehavior === 'auto' ? this.scrollBehavior = 'smooth' : this.scrollBehavior = 'auto'
           }
         }, [
@@ -154,7 +161,10 @@ export default defineComponent({
         itemSize: 34,
         items: randomHeightData,
         itemResizable: true,
-        ref: 'listElRef'
+        ref: 'listElRef',
+        onScroll: (e) => {
+          console.log('onScroll', e)
+        }
       }, {
         default ({ item }: { item: ItemData }) {
           return h('div', {

--- a/src/virtual-list/src/VirtualList.ts
+++ b/src/virtual-list/src/VirtualList.ts
@@ -250,7 +250,7 @@ export default defineComponent({
         const toIndex = keyIndexMapRef.value.get(key)
         if (toIndex !== undefined) scrollToIndex(toIndex, behavior, debounce)
       } else if (position === 'bottom') {
-        scrollToPosition(0, Number.MAX_SAFE_INTEGER, behavior)
+        scrollToBottom()
       } else if (position === 'top') {
         scrollToPosition(0, 0, behavior)
       }
@@ -311,6 +311,31 @@ export default defineComponent({
         behavior
       })
     }
+
+    let isScrollingToBottom = false
+    function scrollToBottom (): void {
+      const listEl = listElRef.value
+      if (isScrollingToBottom || listEl === null) return
+
+      isScrollingToBottom = true
+      const ensureScrollToBottom = (): void => {
+        const { scrollHeight, clientHeight } = listEl
+        const targetScrollTop = scrollHeight + clientHeight
+        listEl.scrollTop = targetScrollTop
+        requestAnimationFrame(() => {
+          listEl.scrollTop = targetScrollTop
+          const isHeightCalculated = scrollHeight === finweckTreeRef.value.sum()
+          if (isHeightCalculated) {
+            isScrollingToBottom = false
+            return
+          }
+          requestAnimationFrame(ensureScrollToBottom)
+        })
+      }
+
+      ensureScrollToBottom()
+    }
+
     function handleItemResize (
       key: string | number,
       entry: ResizeObserverEntry


### PR DESCRIPTION
seems `scrollTo({postion:'bottom'})` can not reach the bottom when scollend

It's possible that the browser thinks it's scrolled to the bottom because it doesn't fully render when scrolling.

use `requestAnimationFrame` to calc whether render completed by scrollHeight and the of all item

