### PR TITLE
fix(virtual-list): prevent scrollTo from executing if listElRef is null

### DIFF
--- a/src/virtual-list/src/VirtualList.ts
+++ b/src/virtual-list/src/VirtualList.ts
@@ -305,7 +305,8 @@ export default defineComponent({
       top: number | undefined,
       behavior: ScrollToOptions['behavior']
     ): void {
-      (listElRef.value as HTMLDivElement).scrollTo({
+      if (listElRef.value == null) return
+      ;(listElRef.value as HTMLDivElement).scrollTo({
         left,
         top,
         behavior


### PR DESCRIPTION

When using keep-alive, it may be empty

```js
activated hook TypeError: Cannot read properties of null (reading 'scrollTo')
```